### PR TITLE
Median diff improved

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -97,39 +97,55 @@
  function indexOfMedianDiffOutliers (arr, threshold) {
    threshold = threshold || 3 // Default threshold of 3 std
    var differencesArr = differences(arr)
+   var medianArr = median(arr)
    var medianDiff = median(differencesArr)
+   var flag = true
+   var index = 0
 
    return arr.reduce(function (res, val, i) {
-     if (isMedianDiffOutlier(threshold, differencesArr[i], medianDiff)) {
-       res.push(i)
+     if (i > 0 && flag) {
+       flag = !isMedianDiffOutlier(threshold, differencesArr[i], medianDiff)
+       index = i
+       if (isMedianDiffOutlier(threshold, differencesArr[i], medianDiff)) {
+         res.push(i)
+       }
+     } else {
+       if (i !== 0) {
+         flag = !(Math.round(Math.abs(arr[index - 1] - arr[i] + 1) / medianDiff) > threshold)
+         if ((Math.round(Math.abs(arr[index - 1] - arr[i])) + 1) / medianDiff > threshold) {
+           res.push(i)
+         }
+       } else {
+         if (!(arr[i] < medianArr + threshold * medianDiff)) {
+           res.push(i)
+         }
+       }
      }
      return res
    }, [])
  }
 
  function filterMedianDiffOutliers (arr, threshold) {
-   threshold = threshold || 3 // Default threshold of 3 std
+   threshold = threshold || 2 // Default threshold of 3 std
    var differencesArr = differences(arr)
-   var medianArr = median(arr);
+   var medianArr = median(arr)
    var medianDiff = median(differencesArr)
-   var flag = true;
-   var index = 0;
-   return arr.filter(function (_, i){
-     if(i>0 && flag){
-         flag = !isMedianDiffOutlier(threshold, differencesArr[i], medianDiff)
-         index = i;
-         return !isMedianDiffOutlier(threshold, differencesArr[i], medianDiff)
+   var flag = true
+   var index = 0
+   return arr.filter(function (_, i) {
+     if (i > 0 && flag) {
+       flag = !isMedianDiffOutlier(threshold, differencesArr[i], medianDiff)
+       index = i
+       return !isMedianDiffOutlier(threshold, differencesArr[i], medianDiff)
+     } else {
+       if (i !== 0) {
+         flag = !(Math.round(Math.abs(arr[index - 1] - arr[i] + 1) / medianDiff) > threshold)
+         return !((Math.round(Math.abs(arr[index - 1] - arr[i])) + 1) / medianDiff > threshold)
+       } else {
+         return arr[i] < medianArr + threshold * medianDiff
        }
-     else{
-       if(i!=0){
-
-         flag = !(Math.round(Math.abs(arr[index-1] - arr[i]+1)/medianDiff) > threshold)
-         return !((Math.round(Math.abs(arr[index-1] - arr[i]))+1)/medianDiff > threshold)
-       }else{
-       return arr[i] < medianArr + threshold*medianDiff;
      }
-     }
-     })
+   })
  }
 
  function filterOutliers (arr, method, threshold) {
@@ -149,18 +165,18 @@
        return indexOfMedianDiffOutliers(arr, threshold)
    }
  }
- 
-module.exports = {
-  stdev: stdev,
-  mean: mean,
-  median: median,
-  MAD: medianAbsoluteDeviation,
-  numSorter: numSorter,
-  outlierMethod: outlierMethod,
-  filterOutliers: filterOutliers,
-  indexOfOutliers: indexOfOutliers,
-  filterMADoutliers: filterMADoutliers,
-  indexOfMADoutliers: indexOfMADoutliers,
-  filterMedianDiffOutliers: filterMedianDiffOutliers,
-  indexOfMedianDiffOutliers: indexOfMedianDiffOutliers
-}
+
+ module.exports = {
+   stdev: stdev,
+   mean: mean,
+   median: median,
+   MAD: medianAbsoluteDeviation,
+   numSorter: numSorter,
+   outlierMethod: outlierMethod,
+   filterOutliers: filterOutliers,
+   indexOfOutliers: indexOfOutliers,
+   filterMADoutliers: filterMADoutliers,
+   indexOfMADoutliers: indexOfMADoutliers,
+   filterMedianDiffOutliers: filterMedianDiffOutliers,
+   indexOfMedianDiffOutliers: indexOfMedianDiffOutliers
+ }

--- a/stats.js
+++ b/stats.js
@@ -7,134 +7,149 @@
  * - Remove outliers from an array of numbers
  */
 
-var outlierMethod = {
-  MAD: 'MAD',
-  medianDiff: 'medianDiff'
-}
+ var outlierMethod = {
+   MAD: 'MAD',
+   medianDiff: 'medianDiff'
+ }
 
-function mean (arr) {
-  return (arr.reduce(function (prev, curr) {
-    return prev + curr
-  }) / arr.length)
-}
+ function mean (arr) {
+   return (arr.reduce(function (prev, curr) {
+     return prev + curr
+   }) / arr.length)
+ }
 
-function variance (arr) {
-  var dataMean = mean(arr)
+ function variance (arr) {
+   var dataMean = mean(arr)
 
-  return mean(arr.map(function (val) {
-    return Math.pow(val - dataMean, 2)
-  }))
-}
+   return mean(arr.map(function (val) {
+     return Math.pow(val - dataMean, 2)
+   }))
+ }
 
-function stdev (arr) {
-  return Math.sqrt(variance(arr))
-}
+ function stdev (arr) {
+   return Math.sqrt(variance(arr))
+ }
 
-function median (arr) {
-  var half = Math.floor(arr.length / 2)
-  arr = arr.slice(0).sort(numSorter)
+ function median (arr) {
+   var half = Math.floor(arr.length / 2)
+   arr = arr.slice(0).sort(numSorter)
 
-  if (arr.length % 2) { // Odd length, true middle element
-    return arr[half]
-  } else { // Even length, average middle two elements
-    return (arr[half - 1] + arr[half]) / 2.0
-  }
-}
+   if (arr.length % 2) { // Odd length, true middle element
+     return arr[half]
+   } else { // Even length, average middle two elements
+     return (arr[half - 1] + arr[half]) / 2.0
+   }
+ }
 
-function medianAbsoluteDeviation (arr, dataMedian) {
-  dataMedian = dataMedian || median(arr)
-  var absoluteDeviation = arr.map(function (val) {
-    return Math.abs(val - dataMedian)
-  })
+ function medianAbsoluteDeviation (arr, dataMedian) {
+   dataMedian = dataMedian || median(arr)
+   var absoluteDeviation = arr.map(function (val) {
+     return Math.abs(val - dataMedian)
+   })
 
-  return median(absoluteDeviation)
-}
+   return median(absoluteDeviation)
+ }
 
-function numSorter (a, b) {
-  return a - b
-}
+ function numSorter (a, b) {
+   return a - b
+ }
 
-// Iglewicz and Hoaglin method
-//  values with a Z-score > 3.5 are considered potential outliers
-function isMADoutlier (val, threshold, dataMedian, dataMAD) {
-  return Math.abs((0.6745 * (val - dataMedian)) / dataMAD) > threshold
-}
+ // Iglewicz and Hoaglin method
+ //  values with a Z-score > 3.5 are considered potential outliers
+ function isMADoutlier (val, threshold, dataMedian, dataMAD) {
+   return Math.abs((0.6745 * (val - dataMedian)) / dataMAD) > threshold
+ }
 
-function indexOfMADoutliers (arr, threshold) {
-  threshold = threshold || 3.5 // Default recommended threshold
-  var dataMedian = median(arr)
-  var dataMAD = medianAbsoluteDeviation(arr, dataMedian)
+ function indexOfMADoutliers (arr, threshold) {
+   threshold = threshold || 3.5 // Default recommended threshold
+   var dataMedian = median(arr)
+   var dataMAD = medianAbsoluteDeviation(arr, dataMedian)
 
-  return arr.reduce(function (res, val, i) {
-    if (isMADoutlier(val, threshold, dataMedian, dataMAD)) {
-      res.push(i)
-    }
-    return res
-  }, [])
-}
+   return arr.reduce(function (res, val, i) {
+     if (isMADoutlier(val, threshold, dataMedian, dataMAD)) {
+       res.push(i)
+     }
+     return res
+   }, [])
+ }
 
-function filterMADoutliers (arr, threshold) {
-  threshold = threshold || 3.5 // Default recommended threshold
-  var dataMedian = median(arr)
-  var dataMAD = medianAbsoluteDeviation(arr, dataMedian)
+ function filterMADoutliers (arr, threshold) {
+   threshold = threshold || 3.5 // Default recommended threshold
+   var dataMedian = median(arr)
+   var dataMAD = medianAbsoluteDeviation(arr, dataMedian)
 
-  return arr.filter(function (val) {
-    return !isMADoutlier(val, threshold, dataMedian, dataMAD)
-  })
-}
+   return arr.filter(function (val) {
+     return !isMADoutlier(val, threshold, dataMedian, dataMAD)
+   })
+ }
 
-// Median filtering from difference between values
-function differences (arr) {
-  return arr.map(function (d, i) {
-    return Math.round(Math.abs(d - (arr[i - 1] || d[0]))) + 1
-  })
-}
+ // Median filtering from difference between values
+ function differences (arr) {
+   return arr.map(function (d, i) {
+     return Math.round(Math.abs(d - (arr[i - 1] || d[0]))) + 1
+   })
+ }
 
-function isMedianDiffOutlier (threshold, difference, medianDiff) {
-  return difference / medianDiff > threshold
-}
+ function isMedianDiffOutlier (threshold, difference, medianDiff) {
+   return difference / medianDiff > threshold
+ }
 
-function indexOfMedianDiffOutliers (arr, threshold) {
-  threshold = threshold || 3 // Default threshold of 3 std
-  var differencesArr = differences(arr)
-  var medianDiff = median(differencesArr)
+ function indexOfMedianDiffOutliers (arr, threshold) {
+   threshold = threshold || 3 // Default threshold of 3 std
+   var differencesArr = differences(arr)
+   var medianDiff = median(differencesArr)
 
-  return arr.reduce(function (res, val, i) {
-    if (isMedianDiffOutlier(threshold, differencesArr[i], medianDiff)) {
-      res.push(i)
-    }
-    return res
-  }, [])
-}
+   return arr.reduce(function (res, val, i) {
+     if (isMedianDiffOutlier(threshold, differencesArr[i], medianDiff)) {
+       res.push(i)
+     }
+     return res
+   }, [])
+ }
 
-function filterMedianDiffOutliers (arr, threshold) {
-  threshold = threshold || 3 // Default threshold of 3 std
-  var differencesArr = differences(arr)
-  var medianDiff = median(differencesArr)
+ function filterMedianDiffOutliers (arr, threshold) {
+   threshold = threshold || 3 // Default threshold of 3 std
+   var differencesArr = differences(arr)
+   var medianArr = median(arr);
+   var medianDiff = median(differencesArr)
+   var flag = true;
+   var index = 0;
+   return arr.filter(function (_, i){
+     if(i>0 && flag){
+         flag = !isMedianDiffOutlier(threshold, differencesArr[i], medianDiff)
+         index = i;
+         return !isMedianDiffOutlier(threshold, differencesArr[i], medianDiff)
+       }
+     else{
+       if(i!=0){
 
-  return arr.filter(function (_, i) {
-    return !isMedianDiffOutlier(threshold, differencesArr[i], medianDiff)
-  })
-}
+         flag = !(Math.round(Math.abs(arr[index-1] - arr[i]+1)/medianDiff) > threshold)
+         return !((Math.round(Math.abs(arr[index-1] - arr[i]))+1)/medianDiff > threshold)
+       }else{
+       return arr[i] < medianArr + threshold*medianDiff;
+     }
+     }
+     })
+ }
 
-function filterOutliers (arr, method, threshold) {
-  switch (method) {
-    case outlierMethod.MAD:
-      return filterMADoutliers(arr, threshold)
-    default:
-      return filterMedianDiffOutliers(arr, threshold)
-  }
-}
+ function filterOutliers (arr, method, threshold) {
+   switch (method) {
+     case outlierMethod.MAD:
+       return filterMADoutliers(arr, threshold)
+     default:
+       return filterMedianDiffOutliers(arr, threshold)
+   }
+ }
 
-function indexOfOutliers (arr, method, threshold) {
-  switch (method) {
-    case outlierMethod.MAD:
-      return indexOfMADoutliers(arr, threshold)
-    default:
-      return indexOfMedianDiffOutliers(arr, threshold)
-  }
-}
-
+ function indexOfOutliers (arr, method, threshold) {
+   switch (method) {
+     case outlierMethod.MAD:
+       return indexOfMADoutliers(arr, threshold)
+     default:
+       return indexOfMedianDiffOutliers(arr, threshold)
+   }
+ }
+ 
 module.exports = {
   stdev: stdev,
   mean: mean,

--- a/stats.js
+++ b/stats.js
@@ -126,7 +126,7 @@
  }
 
  function filterMedianDiffOutliers (arr, threshold) {
-   threshold = threshold || 2 // Default threshold of 3 std
+   threshold = threshold || 3 // Default threshold of 3 std
    var differencesArr = differences(arr)
    var medianArr = median(arr)
    var medianDiff = median(differencesArr)

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ var stats = require('./stats')
 
 var arrOddLen = [-2, 1, 2, 2, 3, 4, 15]
 var arrEvenLen = [1, 2, 2, 3.4, 2.2, 19, 5.2, 1.3, 3.3, 4.1]
-var randomData = [0.9, 0.74, 0.41, 2518, 0.64, 1.7, 0.63, 0.39,
+var randomData = [0.9, 0.74, 0.41, 2518, 64, 1.7, 0.63, 0.39,
   1.54, 0.277, 2.27, 0.37, 0.56, 0.2005, 3, 2.15, 0.78, 3.15, 2,
   0.29, 0.76, 1.38, 1.09, 2.6, 1.26, 0.83, 0.63, 2.98, 1.4, 0.36,
   0.59, 2.1, 1.58, 0.211, 0.65, 1.18, 2.95, 0.7, 0.22, 0.55, 0.37,
@@ -131,9 +131,9 @@ describe('Filter Outliers', function () {
 
 describe('Index of Outliers', function () {
   assert.equal(stats.indexOfOutliers(randomData).length, 2)
-  assert.equal(stats.indexOfOutliers(randomData, stats.outlierMethod.MAD).length, 10)
+  assert.equal(stats.indexOfOutliers(randomData, stats.outlierMethod.MAD).length, 11)
 
   var arr = [5000, 4900, 1000, 3000, 4400, 1200300, 5000, 5500, 126500]
   assert.equal(stats.indexOfOutliers(arr, stats.outlierMethod.MAD).join(','), '2,5,8')
-  assert.equal(stats.indexOfOutliers(arr, stats.outlierMethod.MedianDiff).join(','), '5,6,8')
+  assert.equal(stats.indexOfOutliers(arr, stats.outlierMethod.MedianDiff).join(','), '5,8')
 })


### PR DESCRIPTION
The last median diff function was not working in the following cases:
1: When the outlier is the first element in array
2: When there are two or more consecutive outliers within the same range, like 58, 54.
3: Also it used to remove the element following the outlier too, due to which there was data loss, which has also been fixed